### PR TITLE
recovery.fstab : fix ro.boottime.init.mount.cache setup

### DIFF
--- a/recovery/root/system/etc/recovery.fstab
+++ b/recovery/root/system/etc/recovery.fstab
@@ -27,10 +27,10 @@
 
 
 #<src>                        <mnt_point>     <type>       <mnt_flags and options>    <fs_mgr_flags>
-system                         /system         ext4        ro,barrier=1,discard      avb=vbmeta,logical,first_stage_mount
-vendor                         /vendor         ext4        ro,barrier=1,discard      avb,logical,first_stage_mount
-product                        /product        ext4        ro,barrier=1,discard      avb,logical,first_stage_mount
-odm                            /odm            ext4        ro,barrier=1,discard      avb,logical,first_stage_mount
+system                         /system         ext4        ro,barrier=1,discard      logical,first_stage_mount
+vendor                         /vendor         ext4        ro,barrier=1,discard      logical,first_stage_mount
+product                        /product        ext4        ro,barrier=1,discard      logical,first_stage_mount
+odm                            /odm            ext4        ro,barrier=1,discard      logical,first_stage_mount
 
 /dev/block/mapper/vendor       /vendor_image   emmc        flags=backup=0\;flashimg=1\;display=\"Vendor-Image\"";
 /dev/block/mapper/system       /system_image   emmc        flags=backup=0\;flashimg=1\;display=\"System-Image\"";


### PR DESCRIPTION
init: Unable to set property 'ro.boottime.init.mount.cache' from uid:0 gid:0 pid:3939: Read-only property was already set Prevent avb to mess up the booting of system